### PR TITLE
ci: update golangci-lint action

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,7 +25,7 @@ jobs:
           go mod vendor
 
       - name: Run linters
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.31
 
@@ -55,7 +55,7 @@ jobs:
           go mod vendor
 
       - name: Run linters
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.31
           working-directory: gopgv9
@@ -86,7 +86,7 @@ jobs:
           go mod vendor
 
       - name: Run linters
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.31
           working-directory: gopgv10


### PR DESCRIPTION
It seems that the current version fails due to Go version inconsistency, e.g. https://github.com/hypnoglow/go-pg-monitor/runs/6372262774?check_suite_focus=true

It is suggested to use v3, see: https://github.com/golangci/golangci-lint-action#compatibility