### PR TITLE
Update golangci-lint to v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,9 +25,9 @@ jobs:
           go mod vendor
 
       - name: Run linters
-        uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v1.31
+          version: v2.1
           args: --verbose
 
       - name: Run tests
@@ -56,9 +56,9 @@ jobs:
           go mod vendor
 
       - name: Run linters
-        uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v1.31
+          version: v2.1
           working-directory: gopgv9
           args: --verbose
 
@@ -88,9 +88,9 @@ jobs:
           go mod vendor
 
       - name: Run linters
-        uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v1.31
+          version: v2.1
           working-directory: gopgv10
           args: --verbose
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,6 @@
-version: "2"
+# Reference: https://golangci-lint.run/usage/configuration/
 
-run:
-  concurrency: 4
-  timeout: 5m
+version: "2"
 
 linters:
   default: none
@@ -11,13 +9,13 @@ linters:
     - goconst
     - gocritic
     - gocyclo
-    - revive
     - gosec
     - govet
     - ineffassign
     - misspell
     - nakedret
     - prealloc
+    - revive
     - staticcheck
     - unconvert
     - unparam
@@ -35,21 +33,22 @@ linters:
     rules:
       - linters:
           - revive
-        text: type name will be used as monitor.MonitorOption
+        text: (type name will be used as monitor.MonitorOption|func name will be used as monitor.MonitorWithPoolName)
 
 formatters:
   enable:
     - gci
     - gofmt
-    - goimports
   settings:
     gci:
       sections:
         - standard
         - default
         - prefix(github.com/hypnoglow/go-pg-monitor)
-    goimports:
-      local-prefixes: github.com/hypnoglow/go-pg-monitor
 
 issues:
   fix: true
+
+run:
+  timeout: 5m
+  build-tags: []

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,45 +1,55 @@
+version: "2"
+
 run:
   concurrency: 4
   timeout: 5m
 
 linters:
-  disable-all: true
+  default: none
   enable:
-    - deadcode
-    - depguard
     - errcheck
-    - gci
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
-    - goimports
-    - golint
+    - revive
     - gosec
-    - gosimple
     - govet
     - ineffassign
-    - interfacer
-    - maligned
     - misspell
     - nakedret
     - prealloc
-    - scopelint
     - staticcheck
-    - structcheck
-    - stylecheck
-    - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
+  settings:
+    gocritic:
+      disabled-checks:
+        - singleCaseSwitch
+  exclusions:
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - revive
+        text: type name will be used as monitor.MonitorOption
 
-linters-settings:
-  goimports:
-    local-prefixes: github.com/hypnoglow/go-pg-monitor
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/hypnoglow/go-pg-monitor)
+    goimports:
+      local-prefixes: github.com/hypnoglow/go-pg-monitor
 
 issues:
-  exclude-rules:
-    - linters:
-        - golint
-      text: type name will be used as monitor.MonitorOption
+  fix: true

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+golangci-lint 2.1.6
+golang 1.24.3

--- a/monitor.go
+++ b/monitor.go
@@ -29,7 +29,7 @@ type Monitor struct {
 type MonitorOption func(monitor *Monitor)
 
 // MonitorWithPoolName is an option that sets pool name for the monitor.
-func MonitorWithPoolName(poolName string) MonitorOption { //nolint:golint
+func MonitorWithPoolName(poolName string) MonitorOption {
 	return func(monitor *Monitor) {
 		monitor.poolName = poolName
 	}


### PR DESCRIPTION
## Summary
- pin golangci-lint action to v8 and use linter v2.1
- convert `.golangci.yml` to v2 using `golangci-lint migrate`
- move exclusion rules under `linters.exclusions` and remove `depguard`
- enable default formatting presets and preset-based exclusions

## Testing
- `go test ./...`
- `golangci-lint run` *(fails: revive issue)*

------
https://chatgpt.com/codex/tasks/task_e_6846078fd1e0833087e82095eb17ff3c